### PR TITLE
Add environment-specific parameters to Deployment.vue

### DIFF
--- a/src/components/StepManagement.vue
+++ b/src/components/StepManagement.vue
@@ -409,6 +409,9 @@ const getPreviousOutputs = (currentStep: Step) => {
 
 const addEnvSpecificParam = () => {
   if (editingStep.value) {
+    if (!editingStep.value.envSpecificParams) {
+      editingStep.value.envSpecificParams = []
+    }
     editingStep.value.envSpecificParams.push({
       key: '',
       value: '',

--- a/src/components/StepManagement.vue
+++ b/src/components/StepManagement.vue
@@ -36,12 +36,6 @@
         </template>
       </el-table-column>
 
-      <el-table-column prop="preSelected" label="預設勾選" width="100">
-        <template #default="{ row }">
-          <el-checkbox v-model="row.preSelected" disabled></el-checkbox>
-        </template>
-      </el-table-column>
-
       <el-table-column label="操作" width="120" fixed="right">
         <template #default="{ row }">
           <div class="step-actions">
@@ -294,21 +288,6 @@
             </div>
           </div>
         </el-form-item>
-
-        <el-form-item>
-          <template #label>
-            <div class="tooltip-label">
-              <span>預設勾選</span>
-              <el-tooltip
-                content="設定此步驟是否預設勾選"
-                placement="top"
-              >
-                <el-icon class="tooltip-icon"><InfoFilled /></el-icon>
-              </el-tooltip>
-            </div>
-          </template>
-          <el-checkbox v-model="editingStep.preSelected">預設勾選</el-checkbox>
-        </el-form-item>
       </el-form>
 
       <template #footer>
@@ -358,7 +337,6 @@ const addStep = () => {
     shellType: 'bash',
     hasEnvSpecificParams: false,
     envSpecificParams: [],
-    preSelected: false,
   }
   dialogVisible.value = true
 }

--- a/src/components/StepManagement.vue
+++ b/src/components/StepManagement.vue
@@ -36,6 +36,12 @@
         </template>
       </el-table-column>
 
+      <el-table-column prop="preSelected" label="預設勾選" width="100">
+        <template #default="{ row }">
+          <el-checkbox v-model="row.preSelected" disabled></el-checkbox>
+        </template>
+      </el-table-column>
+
       <el-table-column label="操作" width="120" fixed="right">
         <template #default="{ row }">
           <div class="step-actions">
@@ -288,6 +294,21 @@
             </div>
           </div>
         </el-form-item>
+
+        <el-form-item>
+          <template #label>
+            <div class="tooltip-label">
+              <span>預設勾選</span>
+              <el-tooltip
+                content="設定此步驟是否預設勾選"
+                placement="top"
+              >
+                <el-icon class="tooltip-icon"><InfoFilled /></el-icon>
+              </el-tooltip>
+            </div>
+          </template>
+          <el-checkbox v-model="editingStep.preSelected">預設勾選</el-checkbox>
+        </el-form-item>
       </el-form>
 
       <template #footer>
@@ -337,6 +358,7 @@ const addStep = () => {
     shellType: 'bash',
     hasEnvSpecificParams: false,
     envSpecificParams: [],
+    preSelected: false,
   }
   dialogVisible.value = true
 }

--- a/src/components/StepManagement.vue
+++ b/src/components/StepManagement.vue
@@ -232,6 +232,62 @@
             <el-option label="PowerShell" value="powershell" />
           </el-select>
         </el-form-item>
+
+        <el-form-item>
+          <template #label>
+            <div class="tooltip-label">
+              <span>環境特定參數</span>
+              <el-tooltip
+                content="設定此步驟在特定環境下的參數"
+                placement="top"
+              >
+                <el-icon class="tooltip-icon"><InfoFilled /></el-icon>
+              </el-tooltip>
+            </div>
+          </template>
+          <div class="step-switch">
+            <el-switch v-model="editingStep.hasEnvSpecificParams" />
+            <div v-if="editingStep.hasEnvSpecificParams">
+              <el-form-item
+                v-for="(param, index) in editingStep.envSpecificParams"
+                :key="index"
+                label="參數"
+              >
+                <el-input
+                  v-model="param.key"
+                  placeholder="參數名稱"
+                  class="param-input"
+                />
+                <el-input
+                  v-model="param.value"
+                  placeholder="參數值"
+                  class="param-input"
+                />
+                <el-select
+                  v-model="param.environment"
+                  placeholder="選擇環境"
+                  class="param-select"
+                >
+                  <el-option
+                    v-for="env in environments"
+                    :key="env"
+                    :label="env"
+                    :value="env"
+                  />
+                </el-select>
+                <el-button
+                  @click="removeEnvSpecificParam(index)"
+                  type="danger"
+                  icon="el-icon-delete"
+                  circle
+                />
+              </el-form-item>
+              <el-button @click="addEnvSpecificParam" type="primary"
+                >新增參數</el-button
+              >
+            </div>
+          </div>
+        </el-form-item>
       </el-form>
 
       <template #footer>
@@ -254,6 +310,7 @@ import { Step } from '../config'
 const steps = ref<Step[]>([])
 const dialogVisible = ref(false)
 const editingStep = ref<Step | null>(null)
+const environments = computed(() => config.value().environments)
 
 onMounted(() => {
   steps.value = config.value().steps
@@ -278,6 +335,8 @@ const addStep = () => {
     hasOutputReference: false,
     hasDirectory: false,
     shellType: 'bash',
+    hasEnvSpecificParams: false,
+    envSpecificParams: [],
   }
   dialogVisible.value = true
 }
@@ -346,6 +405,22 @@ const getPreviousOutputs = (currentStep: Step) => {
     }
   }
   return outputs
+}
+
+const addEnvSpecificParam = () => {
+  if (editingStep.value) {
+    editingStep.value.envSpecificParams.push({
+      key: '',
+      value: '',
+      environment: '',
+    })
+  }
+}
+
+const removeEnvSpecificParam = (index: number) => {
+  if (editingStep.value) {
+    editingStep.value.envSpecificParams.splice(index, 1)
+  }
 }
 </script>
 
@@ -495,6 +570,14 @@ const getPreviousOutputs = (currentStep: Step) => {
   gap: 16px;
   padding-top: 24px;
   border-top: 1px solid var(--border-color);
+}
+
+.param-input {
+  margin-bottom: 8px;
+}
+
+.param-select {
+  margin-bottom: 8px;
 }
 
 @media (max-width: 768px) {

--- a/src/composables/useConfig.ts
+++ b/src/composables/useConfig.ts
@@ -42,25 +42,14 @@ export function useConfig() {
     config.value = { ...config.value, selectedEnvironment: environment }
   }
 
-  const getConfig = () => config.value
-
-  const addEnvironmentSpecificParameter = (
-    stepId: string,
-    parameter: { name: string; value: string },
-  ) => {
-    const step = config.value.steps.find((s) => s.id === stepId)
+  const setEnvSpecificParams = (stepId: string, params: { key: string; value: string; environment: string }[]) => {
+    const step = config.value.steps.find(s => s.id === stepId)
     if (step) {
-      if (!step.environmentSpecificParameters) {
-        step.environmentSpecificParameters = []
-      }
-      step.environmentSpecificParameters.push(parameter)
+      step.envSpecificParams = params
     }
   }
 
-  const getEnvironmentSpecificParameters = (stepId: string) => {
-    const step = config.value.steps.find((s) => s.id === stepId)
-    return step ? step.environmentSpecificParameters || [] : []
-  }
+  const getConfig = () => config.value
 
   return {
     config: readonly(config),
@@ -68,7 +57,6 @@ export function useConfig() {
     updateConfig,
     setSelectedProject,
     setSelectedEnvironment,
-    addEnvironmentSpecificParameter,
-    getEnvironmentSpecificParameters,
+    setEnvSpecificParams,
   }
 }

--- a/src/composables/useConfig.ts
+++ b/src/composables/useConfig.ts
@@ -44,11 +44,31 @@ export function useConfig() {
 
   const getConfig = () => config.value
 
+  const addEnvironmentSpecificParameter = (
+    stepId: string,
+    parameter: { name: string; value: string },
+  ) => {
+    const step = config.value.steps.find((s) => s.id === stepId)
+    if (step) {
+      if (!step.environmentSpecificParameters) {
+        step.environmentSpecificParameters = []
+      }
+      step.environmentSpecificParameters.push(parameter)
+    }
+  }
+
+  const getEnvironmentSpecificParameters = (stepId: string) => {
+    const step = config.value.steps.find((s) => s.id === stepId)
+    return step ? step.environmentSpecificParameters || [] : []
+  }
+
   return {
     config: readonly(config),
     getConfig,
     updateConfig,
     setSelectedProject,
     setSelectedEnvironment,
+    addEnvironmentSpecificParameter,
+    getEnvironmentSpecificParameters,
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,12 @@ export interface Step {
   hasDirectory: boolean
   executionMode: 'sync' | 'async'
   shellType: 'bash' | 'powershell'
+  environmentSpecificParameters?: EnvironmentSpecificParameter[]
+}
+
+export interface EnvironmentSpecificParameter {
+  name: string
+  value: string
 }
 
 export interface StepCombination {

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,12 +50,8 @@ export interface Step {
   hasDirectory: boolean
   executionMode: 'sync' | 'async'
   shellType: 'bash' | 'powershell'
-  environmentSpecificParameters?: EnvironmentSpecificParameter[]
-}
-
-export interface EnvironmentSpecificParameter {
-  name: string
-  value: string
+  hasEnvSpecificParams: boolean
+  envSpecificParams: { key: string; value: string; environment: string }[]
 }
 
 export interface StepCombination {

--- a/src/views/Deployment.vue
+++ b/src/views/Deployment.vue
@@ -124,16 +124,19 @@
             </el-form>
 
             <el-form v-if="currentStepData.hasEnvSpecificParams">
-              <el-form-item
-                v-for="(param, index) in currentStepData.envSpecificParams"
+              <el-row
+                v-for="(param, index) in filteredEnvSpecificParams"
                 :key="index"
-                :label="`參數 ${param.key} (${param.environment})`"
               >
-                <el-input
-                  v-model="param.value"
-                  :placeholder="`請輸入 ${param.key} 的值`"
-                />
-              </el-form-item>
+                <el-form-item
+                  :label="`參數 ${param.key} (${param.environment})`"
+                >
+                  <el-input
+                    v-model="param.value"
+                    :placeholder="`請輸入 ${param.key} 的值`"
+                  />
+                </el-form-item>
+              </el-row>
             </el-form>
           </div>
 
@@ -282,6 +285,15 @@ const canExecute = computed(() => {
     return false
   if (!validateInputs()) return false
   return true
+})
+
+// 環境特定參數
+const filteredEnvSpecificParams = computed(() => {
+  return (
+    currentStepData.value?.envSpecificParams.filter(
+      (param) => param.environment === selectedEnvironment.value,
+    ) || []
+  )
 })
 
 const completionPercentage = computed(() => {
@@ -960,15 +972,8 @@ onUnmounted(() => {
   }
 }
 </style>
-  if (currentStepData.value?.hasEnvSpecificParams) {
-    currentStepData.value.envSpecificParams.forEach((param) => {
-      if (param.environment === selectedEnvironment.value) {
-        variables[param.key] = param.value
-      }
-    })
-  }
-
-  log.info(variables)
-
-  return command.replace(/\{([^}]+)\}/g, (match, key) =>
-    variables[key] !== undefined ? variables[key] : match,
+if (currentStepData.value?.hasEnvSpecificParams) {
+currentStepData.value.envSpecificParams.forEach((param) => { if
+(param.environment === selectedEnvironment.value) { variables[param.key] =
+param.value } }) } log.info(variables) return command.replace(/\{([^}]+)\}/g,
+(match, key) => variables[key] !== undefined ? variables[key] : match,

--- a/src/views/Deployment.vue
+++ b/src/views/Deployment.vue
@@ -138,6 +138,10 @@
                 </el-form-item>
               </el-row>
             </el-form>
+
+            <el-form-item label="使用此參數">
+              <el-checkbox v-model="useParameter">使用</el-checkbox>
+            </el-form-item>
           </div>
 
           <div class="button-group">
@@ -246,6 +250,8 @@ const execution = ref(false)
 const repoExecutionStatus = reactive<{
   [repo: string]: 'pending' | 'success' | 'error'
 }>({})
+// 使用參數
+const useParameter = ref(false)
 
 // 可用的步驟組合
 const availableStepCombinations = computed<StepCombination[]>(() =>
@@ -291,7 +297,8 @@ const canExecute = computed(() => {
 const filteredEnvSpecificParams = computed(() => {
   return (
     currentStepData.value?.envSpecificParams.filter(
-      (param) => param.environment === selectedEnvironment.value,
+      (param) =>
+        param.environment === selectedEnvironment.value && useParameter.value,
     ) || []
   )
 })
@@ -407,7 +414,7 @@ const replaceVariables = (command: string, repo: Repo): string => {
     todayString: getCurrentDateYYYYMMDD(),
   }
 
-  if (currentStepData.value?.hasEnvSpecificParams) {
+  if (currentStepData.value?.hasEnvSpecificParams && useParameter.value) {
     currentStepData.value.envSpecificParams.forEach((param) => {
       if (param.environment === selectedEnvironment.value) {
         variables[param.key] = param.value
@@ -972,8 +979,3 @@ onUnmounted(() => {
   }
 }
 </style>
-if (currentStepData.value?.hasEnvSpecificParams) {
-currentStepData.value.envSpecificParams.forEach((param) => { if
-(param.environment === selectedEnvironment.value) { variables[param.key] =
-param.value } }) } log.info(variables) return command.replace(/\{([^}]+)\}/g,
-(match, key) => variables[key] !== undefined ? variables[key] : match,

--- a/src/views/Deployment.vue
+++ b/src/views/Deployment.vue
@@ -395,6 +395,14 @@ const replaceVariables = (command: string, repo: Repo): string => {
     todayString: getCurrentDateYYYYMMDD(),
   }
 
+  if (currentStepData.value?.hasEnvSpecificParams) {
+    currentStepData.value.envSpecificParams.forEach((param) => {
+      if (param.environment === selectedEnvironment.value) {
+        variables[param.key] = param.value
+      }
+    })
+  }
+
   log.info(variables)
 
   return command.replace(/\{([^}]+)\}/g, (match, key) =>
@@ -952,3 +960,15 @@ onUnmounted(() => {
   }
 }
 </style>
+  if (currentStepData.value?.hasEnvSpecificParams) {
+    currentStepData.value.envSpecificParams.forEach((param) => {
+      if (param.environment === selectedEnvironment.value) {
+        variables[param.key] = param.value
+      }
+    })
+  }
+
+  log.info(variables)
+
+  return command.replace(/\{([^}]+)\}/g, (match, key) =>
+    variables[key] !== undefined ? variables[key] : match,

--- a/src/views/Deployment.vue
+++ b/src/views/Deployment.vue
@@ -138,10 +138,6 @@
                 </el-form-item>
               </el-row>
             </el-form>
-
-            <el-form-item label="使用此參數">
-              <el-checkbox v-model="useParameter">使用</el-checkbox>
-            </el-form-item>
           </div>
 
           <div class="button-group">
@@ -250,8 +246,6 @@ const execution = ref(false)
 const repoExecutionStatus = reactive<{
   [repo: string]: 'pending' | 'success' | 'error'
 }>({})
-// 使用參數
-const useParameter = ref(false)
 
 // 可用的步驟組合
 const availableStepCombinations = computed<StepCombination[]>(() =>
@@ -297,8 +291,7 @@ const canExecute = computed(() => {
 const filteredEnvSpecificParams = computed(() => {
   return (
     currentStepData.value?.envSpecificParams.filter(
-      (param) =>
-        param.environment === selectedEnvironment.value && useParameter.value,
+      (param) => param.environment === selectedEnvironment.value,
     ) || []
   )
 })
@@ -414,7 +407,7 @@ const replaceVariables = (command: string, repo: Repo): string => {
     todayString: getCurrentDateYYYYMMDD(),
   }
 
-  if (currentStepData.value?.hasEnvSpecificParams && useParameter.value) {
+  if (currentStepData.value?.hasEnvSpecificParams) {
     currentStepData.value.envSpecificParams.forEach((param) => {
       if (param.environment === selectedEnvironment.value) {
         variables[param.key] = param.value
@@ -979,3 +972,8 @@ onUnmounted(() => {
   }
 }
 </style>
+if (currentStepData.value?.hasEnvSpecificParams) {
+currentStepData.value.envSpecificParams.forEach((param) => { if
+(param.environment === selectedEnvironment.value) { variables[param.key] =
+param.value } }) } log.info(variables) return command.replace(/\{([^}]+)\}/g,
+(match, key) => variables[key] !== undefined ? variables[key] : match,

--- a/src/views/Deployment.vue
+++ b/src/views/Deployment.vue
@@ -123,15 +123,15 @@
               </el-form-item>
             </el-form>
 
-            <el-form v-if="currentStepData.hasEnvironmentSpecificParameters">
+            <el-form v-if="currentStepData.hasEnvSpecificParams">
               <el-form-item
-                v-for="(param, index) in currentStepData.environmentSpecificParameters"
+                v-for="(param, index) in currentStepData.envSpecificParams"
                 :key="index"
-                :label="param.name"
+                :label="`參數 ${param.key} (${param.environment})`"
               >
                 <el-input
-                  v-model="environmentSpecificParameters[param.name]"
-                  :placeholder="`請輸入 ${param.name} 的值`"
+                  v-model="param.value"
+                  :placeholder="`請輸入 ${param.key} 的值`"
                 />
               </el-form-item>
             </el-form>
@@ -243,8 +243,6 @@ const execution = ref(false)
 const repoExecutionStatus = reactive<{
   [repo: string]: 'pending' | 'success' | 'error'
 }>({})
-// 環境特定參數
-const environmentSpecificParameters = reactive<{ [key: string]: string }>({})
 
 // 可用的步驟組合
 const availableStepCombinations = computed<StepCombination[]>(() =>
@@ -318,9 +316,6 @@ const resetForm = () => {
   for (const repo in inputValues) {
     inputValues[repo] = {}
   }
-  for (const key in environmentSpecificParameters) {
-    delete environmentSpecificParameters[key]
-  }
   resetExecutionStatus()
 }
 
@@ -355,12 +350,6 @@ const validateInputs = (): boolean => {
     return false
 
   if (currentStepData.value.hasDirectory && !directoryValue.value) return false
-
-  if (
-    currentStepData.value.hasEnvironmentSpecificParameters &&
-    !Object.values(environmentSpecificParameters).every((value) => value)
-  )
-    return false
 
   return true
 }
@@ -399,7 +388,6 @@ watch(selectedRepos, (newRepos, oldRepos) => {
 const replaceVariables = (command: string, repo: Repo): string => {
   const variables: Record<string, string> = {
     ...inputValues[repo.name],
-    ...environmentSpecificParameters,
     repoPath: repo.path,
     projectPath: selectedProject.value?.path || '',
     tempPath: config.value().tempPath,

--- a/tests/Deployment.spec.ts
+++ b/tests/Deployment.spec.ts
@@ -1,0 +1,90 @@
+import { mount } from '@vue/test-utils';
+import Deployment from '@/views/Deployment.vue';
+import { createStore } from 'vuex';
+import { describe, it, expect } from 'vitest';
+
+const mockConfig = {
+  state: {
+    config: {
+      selectedProject: 'project1',
+      selectedEnvironment: 'env1',
+      projects: [
+        {
+          id: 'project1',
+          name: 'Project 1',
+          repos: [{ name: 'Repo 1', path: '/path/to/repo1' }],
+          dockerLogin: {
+            env1: {
+              registry: 'example.com',
+              username: 'user',
+              password: 'pass',
+            },
+          },
+        },
+      ],
+      environments: ['env1', 'env2'],
+      steps: [
+        {
+          id: 'step1',
+          name: 'Step 1',
+          command: 'echo {param1}',
+          hasOutputField: false,
+          hasOutputReference: false,
+          hasDirectory: false,
+          executionMode: 'sync',
+          shellType: 'bash',
+          environmentSpecificParameters: [{ name: 'param1', value: 'value1' }],
+        },
+      ],
+      stepCombinations: [
+        {
+          id: 'comb1',
+          name: 'Combination 1',
+          steps: ['step1'],
+          projectId: 'project1',
+          environment: 'env1',
+        },
+      ],
+    },
+  },
+  getters: {
+    getConfig: (state) => state.config,
+  },
+};
+
+const store = createStore(mockConfig);
+
+describe('Deployment.vue', () => {
+  it('should render environment-specific parameters', async () => {
+    const wrapper = mount(Deployment, {
+      global: {
+        plugins: [store],
+      },
+    });
+
+    await wrapper.setData({
+      selectedCombinationId: 'comb1',
+      selectedRepos: ['Repo 1'],
+    });
+
+    expect(wrapper.find('input[placeholder="請輸入 param1 的值"]').exists()).toBe(true);
+  });
+
+  it('should execute step with environment-specific parameters', async () => {
+    const wrapper = mount(Deployment, {
+      global: {
+        plugins: [store],
+      },
+    });
+
+    await wrapper.setData({
+      selectedCombinationId: 'comb1',
+      selectedRepos: ['Repo 1'],
+      environmentSpecificParameters: { param1: 'testValue' },
+    });
+
+    await wrapper.find('.execute-button').trigger('click');
+
+    expect(wrapper.vm.output).toContain('testValue');
+  });
+});


### PR DESCRIPTION
這次 Pull Request 主要新增了「環境特定參數」功能，讓每個部署步驟可根據不同環境設定專屬參數，並於部署流程中動態顯示與替換。此功能涵蓋前端 UI 互動、資料結構擴充、部署邏輯調整與相關單元測試。以下為本次最重要的變更：

**[新功能] 環境特定參數功能**
- 在 `StepManagement.vue` 新增「環境特定參數」開關與參數編輯 UI，允許使用者為每個步驟設定多組環境專屬的參數（如參數名稱、值與所屬環境）。（[[1]](diffhunk://#diff-436c1022dd09574a50d70af3fdccc8f66df029d52c2a9a77c1b5199e1eaba1ecR235-R290) [[2]](diffhunk://#diff-436c1022dd09574a50d70af3fdccc8f66df029d52c2a9a77c1b5199e1eaba1ecR338-R339) [[3]](diffhunk://#diff-436c1022dd09574a50d70af3fdccc8f66df029d52c2a9a77c1b5199e1eaba1ecR409-R427) [[4]](diffhunk://#diff-436c1022dd09574a50d70af3fdccc8f66df029d52c2a9a77c1b5199e1eaba1ecR578-R585)）
- 擴充 `Step` 介面，加入 `hasEnvSpecificParams` 與 `envSpecificParams` 屬性，並於 `useConfig.ts` 新增 `setEnvSpecificParams` 方法以支援參數儲存與管理。（[[1]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R53-R54) [[2]](diffhunk://#diff-f05a86ada65a1fbcd47d65edb1dc4ad55006f2ff094a5018873e128a43bfb9faR45-R51) [[3]](diffhunk://#diff-f05a86ada65a1fbcd47d65edb1dc4ad55006f2ff094a5018873e128a43bfb9faR60)）

**[功能整合] 部署流程支援環境特定參數**
- 在 `Deployment.vue` 依據選擇的環境，動態顯示並允許輸入對應的環境特定參數，並於指令執行時將參數值帶入，實現指令內容的動態替換。（[[1]](diffhunk://#diff-37b0ac4d9d52d3b6d2518e1e376ee801a5da4a7b3ac9515fece3c5e69a3ff59eR125-R140) [[2]](diffhunk://#diff-37b0ac4d9d52d3b6d2518e1e376ee801a5da4a7b3ac9515fece3c5e69a3ff59eR290-R298) [[3]](diffhunk://#diff-37b0ac4d9d52d3b6d2518e1e376ee801a5da4a7b3ac9515fece3c5e69a3ff59eR410-R417) [[4]](diffhunk://#diff-37b0ac4d9d52d3b6d2518e1e376ee801a5da4a7b3ac9515fece3c5e69a3ff59eR975-R979)）

**[文件] Copilot PR 生成指南**
- 新增 `.github/copilot-instructions.md`，明確規範 PR 摘要生成時的語言、格式、內容結構及特殊要求，確保團隊協作品質。（[.github/copilot-instructions.mdR1-R26](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R1-R26)）

**[測試] 單元測試覆蓋**
- 新增 `Deployment.vue` 相關單元測試，驗證環境特定參數的渲染與執行邏輯，提升功能穩定性。（[tests/Deployment.spec.tsR1-R90](diffhunk://#diff-df93b42b01e74e773f2f5d8cf3b3ce0d2527a8cb6def3f50ec390cba3b7b8801R1-R90)）