### PR TITLE
Add a checkbox to decide whether to use a parameter for deployment

### DIFF
--- a/src/components/StepManagement.vue
+++ b/src/components/StepManagement.vue
@@ -36,6 +36,12 @@
         </template>
       </el-table-column>
 
+      <el-table-column prop="preSelected" label="預設勾選" width="100">
+        <template #default="{ row }">
+          <el-checkbox v-model="row.preSelected" disabled></el-checkbox>
+        </template>
+      </el-table-column>
+
       <el-table-column label="操作" width="120" fixed="right">
         <template #default="{ row }">
           <div class="step-actions">
@@ -288,6 +294,21 @@
             </div>
           </div>
         </el-form-item>
+
+        <el-form-item>
+          <template #label>
+            <div class="tooltip-label">
+              <span>預設勾選</span>
+              <el-tooltip
+                content="設定此步驟是否預設勾選"
+                placement="top"
+              >
+                <el-icon class="tooltip-icon"><InfoFilled /></el-icon>
+              </el-tooltip>
+            </div>
+          </template>
+          <el-checkbox v-model="editingStep.preSelected">預設勾選</el-checkbox>
+        </el-form-item>
       </el-form>
 
       <template #footer>
@@ -337,6 +358,7 @@ const addStep = () => {
     shellType: 'bash',
     hasEnvSpecificParams: false,
     envSpecificParams: [],
+    preSelected: false,
   }
   dialogVisible.value = true
 }

--- a/src/views/Deployment.vue
+++ b/src/views/Deployment.vue
@@ -138,6 +138,10 @@
                 </el-form-item>
               </el-row>
             </el-form>
+
+            <el-form-item label="使用此參數">
+              <el-checkbox v-model="useParameter">使用</el-checkbox>
+            </el-form-item>
           </div>
 
           <div class="button-group">
@@ -246,6 +250,8 @@ const execution = ref(false)
 const repoExecutionStatus = reactive<{
   [repo: string]: 'pending' | 'success' | 'error'
 }>({})
+// 使用參數
+const useParameter = ref(false)
 
 // 可用的步驟組合
 const availableStepCombinations = computed<StepCombination[]>(() =>
@@ -291,7 +297,8 @@ const canExecute = computed(() => {
 const filteredEnvSpecificParams = computed(() => {
   return (
     currentStepData.value?.envSpecificParams.filter(
-      (param) => param.environment === selectedEnvironment.value,
+      (param) =>
+        param.environment === selectedEnvironment.value && useParameter.value,
     ) || []
   )
 })
@@ -407,7 +414,7 @@ const replaceVariables = (command: string, repo: Repo): string => {
     todayString: getCurrentDateYYYYMMDD(),
   }
 
-  if (currentStepData.value?.hasEnvSpecificParams) {
+  if (currentStepData.value?.hasEnvSpecificParams && useParameter.value) {
     currentStepData.value.envSpecificParams.forEach((param) => {
       if (param.environment === selectedEnvironment.value) {
         variables[param.key] = param.value
@@ -972,8 +979,3 @@ onUnmounted(() => {
   }
 }
 </style>
-if (currentStepData.value?.hasEnvSpecificParams) {
-currentStepData.value.envSpecificParams.forEach((param) => { if
-(param.environment === selectedEnvironment.value) { variables[param.key] =
-param.value } }) } log.info(variables) return command.replace(/\{([^}]+)\}/g,
-(match, key) => variables[key] !== undefined ? variables[key] : match,


### PR DESCRIPTION
Add a checkbox to decide whether to use a parameter for deployment.

* **Deployment.vue**
  - Add a checkbox labeled "使用此參數" to the form.
  - Add a reactive reference `useParameter` to store the checkbox state.
  - Update `filteredEnvSpecificParams` to filter parameters based on the checkbox state.
  - Update `executeStep` function to check the checkbox state and decide parameter usage.

* **StepManagement.vue**
  - Add a new column "預設勾選" with a checkbox to the table.
  - Add a new form item with a checkbox labeled "預設勾選" to the step editing form.
  - Add a `preSelected` property to the step object to indicate whether it should be pre-selected.

