### PR TITLE
fix: 修復視窗控制按鈕圖示狀態同步問題

### DIFF
--- a/src/electron/ipcHandlers.ts
+++ b/src/electron/ipcHandlers.ts
@@ -220,4 +220,22 @@ export function setupIpcHandlers(mainWindow: BrowserWindow): void {
   ipcMain.on('close-window', () => {
     mainWindow.close()
   })
+
+  // 新增：獲取視窗狀態
+  ipcMain.handle('get-window-state', () => {
+    return {
+      isMaximized: mainWindow.isMaximized(),
+      isMinimized: mainWindow.isMinimized(),
+      isFullScreen: mainWindow.isFullScreen()
+    }
+  })
+
+  // 新增：監聽視窗最大化/還原事件並通知渲染程序
+  mainWindow.on('maximize', () => {
+    mainWindow.webContents.send('window-maximized')
+  })
+
+  mainWindow.on('unmaximize', () => {
+    mainWindow.webContents.send('window-unmaximized')
+  })
 }

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -11,6 +11,8 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.send(channel, ...args),
     removeAllListeners: (channel: string) =>
       ipcRenderer.removeAllListeners(channel),
+    removeListener: (channel: string, listener: (...args: never[]) => void) =>
+      ipcRenderer.removeListener(channel, listener),
     setStoreValue: (key: string, value: never) => {
       ipcRenderer.send('setStore', key, value)
     },


### PR DESCRIPTION
問題修復：
- 視窗放大後圖示仍顯示放大圖示，未正確反映視窗狀態

主要變更：
- WindowControls.vue: 新增 isMaximized 狀態追蹤
- 根據視窗狀態動態切換圖示 (FullScreen/CopyDocument)
- 新增 onMounted/onUnmounted 生命週期管理
- ipcHandlers.ts: 新增 get-window-state IPC 處理程序
- 新增視窗 maximize/unmaximize 事件監聽與通知
- preload.ts: 新增 removeListener 方法支援

技術改進：
- 即時響應視窗狀態變化
- 正確的事件監聽器清理
- 更好的使用者體驗

🤖 Generated with [Claude Code](https://claude.ai/code)